### PR TITLE
Add `es2017`: `comma-dangle` is enabled

### DIFF
--- a/examples/es2017.js
+++ b/examples/es2017.js
@@ -2,4 +2,16 @@
 
 /* eslint-disable no-magic-numbers, no-unused-vars */
 
+// async/await
 const foo = async a => await alert(a);
+
+// comma-dangle for "functions"
+function comma(
+  a,
+  b,
+) {}
+
+comma(
+  1,
+  2,
+);

--- a/examples/es6.js
+++ b/examples/es6.js
@@ -44,7 +44,7 @@ exports.obj = {
   1: 'b',
   foo() {},
   // allow properties
-  Foo: Foo
+  Foo: Foo,
 };
 
 exports.Foo = Foo;

--- a/lib/es2017.js
+++ b/lib/es2017.js
@@ -2,8 +2,18 @@
 
 module.exports = {
   "parserOptions": {
-    "ecmaVersion": 2016,
+    "ecmaVersion": 2017,
     // Specify if ES Modules
     // "sourceType": "module",
+
+    // ## Override
+    // ES2017 allows trailing comma in functions
+    "comma-dangle": [2, {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "functions": "always-multiline",
+    }],
   },
 };

--- a/lib/es2017.js
+++ b/lib/es2017.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+  "parserOptions": {
+    "ecmaVersion": 2016,
+    // Specify if ES Modules
+    // "sourceType": "module",
+  },
+};

--- a/lib/es6.js
+++ b/lib/es6.js
@@ -40,5 +40,7 @@ module.exports = {
     // ## Override
     // Use ES6 const
     "no-magic-numbers": [1, {"ignoreArrayIndexes": true, "enforceConst": true}],
-  }
+    // ES5 or later allow trailing comma, exept for "functions"
+    "comma-dangle": [2, "always-multiline"],
+  },
 };

--- a/lib/es6.js
+++ b/lib/es6.js
@@ -41,6 +41,6 @@ module.exports = {
     // Use ES6 const
     "no-magic-numbers": [1, {"ignoreArrayIndexes": true, "enforceConst": true}],
     // ES5 or later allow trailing comma, exept for "functions"
-    "comma-dangle": [2, "always-multiline"],
+    // "comma-dangle": [2, "always-multiline"],
   },
 };

--- a/node-es2017.js
+++ b/node-es2017.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  "extends": [
+    "./lib/base.js",
+    "./lib/node.js",
+    "./lib/es6.js",
+    "./lib/es2017.js",
+  ],
+  "rules": {
+    "node/no-unsupported-features": 0,
+  }
+};

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "closure.js",
     "closure-es6.js",
     "es6.js",
+    "es2017.js",
     "node.js",
     "node-es6.js",
+    "node-es2017.js",
     "node-v4.js",
     "node-v6.js",
     "lib"


### PR DESCRIPTION
- add `es2017`
- `comma-dangle`: `always-multiline` in es2017

In the next BC, `comma-dangle` will be enabled in es6.