### PR TITLE
build: update ESLint to v5.0.0-alpha.3

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -67,7 +67,7 @@ module.exports = {
     'no-return-assign': 2,
     // => es2017
     // overwrite recommended: "no-return-await": 2,
-    'no-self-assign': [2, {props: true}],
+    'no-self-assign': 2,
     'no-self-compare': 2,
     'no-sequences': 2,
     'no-throw-literal': 2,
@@ -123,7 +123,7 @@ module.exports = {
     'no-whitespace-before-property': 2,
     'nonblock-statement-body-position': 0,
     'object-curly-spacing': [2, 'never'],
-    'object-curly-newline': [2, {consistent: true}],
+    'object-curly-newline': 2,
     'operator-assignment': [2, 'always'],
     'operator-linebreak': [2, 'after'],
     'padded-blocks': [2, 'never'],

--- a/lib/es2018.js
+++ b/lib/es2018.js
@@ -6,6 +6,7 @@ module.exports = {
     // Specify if ES Modules
     // "sourceType": "module",
   },
-  globals: {},
-  rules: {},
+  rules: {
+    'prefer-object-spread': 2,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,15 +20,15 @@
       }
     },
     "ajv": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-      "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+      "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "1.1.0",
+        "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1",
-        "uri-js": "3.0.2"
+        "uri-js": "4.2.1"
       }
     },
     "ajv-keywords": {
@@ -376,12 +376,12 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "5.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.0.0-alpha.2.tgz",
-      "integrity": "sha512-3SlE6VxOdnhJ7kK/u49rvITlyJx1wAuduXMwSsuP161ZHOpt+nlgsTPo2QaAOiAxD6xEcSQZGtU0tAh/oyhUyA==",
+      "version": "5.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.0.0-alpha.3.tgz",
+      "integrity": "sha512-TOmowAxcITzoWYx5bYhepDep/ccT9XfOdb9f2K1rCbnqaRFSorZeBF3TKgDa7BMB/LvmOcxok3MNvYP7Ht1SHA==",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
+        "ajv": "6.5.0",
         "babel-code-frame": "6.26.0",
         "chalk": "2.4.1",
         "cross-spawn": "6.0.5",
@@ -414,25 +414,11 @@
         "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
+        "string.prototype.matchall": "2.0.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.3",
         "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        }
       }
     },
     "eslint-config-prettier": {
@@ -556,14 +542,14 @@
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
+        "iconv-lite": "0.4.23",
         "tmp": "0.0.33"
       }
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-diff": {
@@ -719,6 +705,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -732,9 +724,9 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
@@ -1280,6 +1272,15 @@
         "path-type": "3.0.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2"
+      }
+    },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
@@ -1466,6 +1467,19 @@
         "strip-ansi": "4.0.0"
       }
     },
+    "string.prototype.matchall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
+      "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "regexp.prototype.flags": "1.2.0"
+      }
+    },
     "string.prototype.padend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
@@ -1524,7 +1538,7 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
+        "ajv": "6.5.0",
         "ajv-keywords": "3.2.0",
         "chalk": "2.4.1",
         "lodash": "4.17.10",
@@ -1563,9 +1577,9 @@
       }
     },
     "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+      "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
       "dev": true,
       "requires": {
         "punycode": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-prettier": "^2.6.0"
   },
   "devDependencies": {
-    "eslint": "^5.0.0-alpha.2",
+    "eslint": "^5.0.0-alpha.3",
     "glob": "^7.1.2",
     "mocha": "^5.1.1",
     "npm-run-all": "^4.1.3",

--- a/test/fixtures/es2018.prefer-object-spread.fail.js
+++ b/test/fixtures/es2018.prefer-object-spread.fail.js
@@ -1,0 +1,2 @@
+const foo = {a: 1};
+const bar = Object.assign({}, foo)

--- a/test/fixtures/es5.no-self-assign.fail.js
+++ b/test/fixtures/es5.no-self-assign.fail.js
@@ -1,0 +1,1 @@
+obj.a = obj.a;

--- a/test/fixtures/es5.object-curly-newline.fail.js
+++ b/test/fixtures/es5.object-curly-newline.fail.js
@@ -1,0 +1,8 @@
+var a = {foo: 1
+};
+var b = {
+    foo: 1};
+var c = {foo: 1, bar: 2
+};
+var d = {
+    foo: 1, bar: 2};

--- a/test/fixtures/es5.object-curly-newline.pass.js
+++ b/test/fixtures/es5.object-curly-newline.pass.js
@@ -12,6 +12,8 @@ var e = {
     foo: 1,
     bar: 2
 };
+var e2 = {foo: 1,
+    bar: 2};
 var f = {foo: function() {dosomething();}};
 var g = {
     foo: function() {


### PR DESCRIPTION
- https://eslint.org/blog/2018/05/eslint-v5.0.0-alpha.3-released
- [Breaking: new object\-curly\-newline/no\-self\-assign default \(fixes \#10215\) by not\-an\-aardvark · Pull Request \#10337 · eslint/eslint](https://github.com/eslint/eslint/pull/10337)

### Breaking change
- disable `multiline` option of `object-curly-newline` according to new ESLint default