### PR TITLE
build: update peerDeps ESLint to v5.0.0-alpha.3

### DIFF
--- a/node-v10.js
+++ b/node-v10.js
@@ -9,10 +9,6 @@ module.exports = {
     './lib/es2017.js',
     './lib/es2018.js',
   ],
-  globals: {
-    // globals@11.5.0 includes URL and URLSearchParams
-    // https://github.com/sindresorhus/globals/commit/0a57eb52ff7a1c92f227d2441349e0441252e8bb
-  },
   rules: {
     'node/no-unsupported-features': [2, {version: 10}],
   },

--- a/node-v8.js
+++ b/node-v8.js
@@ -7,7 +7,8 @@ module.exports = {
     './lib/es2015.js',
     './lib/es2016.js',
     './lib/es2017.js',
-    // to parse object rest/spread properties
+    // Node v8 has object rest/spread properties,
+    // but doesn't have Promise#finally and async iterators
     './lib/es2018.js',
   ],
   rules: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier": "1.12.1"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0-alpha.2",
+    "eslint": "^5.0.0-alpha.3",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-eslint-comments": "^3.0.0-beta.2",
     "eslint-plugin-node": "^6.0.1",


### PR DESCRIPTION
ESLint@5.0.0-alpha.3 has globals@11.5.0 that has Node v10 globals.

- https://github.com/eslint/eslint/pull/10339