### PR TITLE
feat: replace valid-jsdoc with eslint-plugin-jsdoc

### DIFF
--- a/examples/es5/index.js
+++ b/examples/es5/index.js
@@ -5,8 +5,10 @@
  * Sets multiple properties on a node.
  * @param {Element} element DOM node to set properties on.
  * @param {Object} properties Hash of property:value pairs.
+ * @param {boolean|string|number|null|undefined} a
+ * @return {null}
  */
-function setProperties(element, properties) {
+function setProperties(element, properties, a) {
   Object.keys(properties).forEach(function(key) {
     var val = properties[key];
     if (key === 'style') {
@@ -19,9 +21,19 @@ function setProperties(element, properties) {
       element[key] = val;
     }
   });
+  return null;
 }
 
 setProperties();
+
+/**
+ * @constructor
+ */
+function foo() {}
+
+/**
+ */
+function noparam(a, b) {}
 
 // unicorn
 var s = '\u001B';

--- a/lib/base.js
+++ b/lib/base.js
@@ -4,7 +4,7 @@ require('./assert-no-nested-deps')();
 
 module.exports = {
   extends: ['eslint:recommended', 'plugin:eslint-comments/recommended'],
-  plugins: ['unicorn'],
+  plugins: ['unicorn', 'jsdoc'],
   rules: {
     // ## Possible Errors
     // overwrite recommended: `console` is used for simple stdout/stderr
@@ -13,24 +13,6 @@ module.exports = {
     'no-constant-condition': [2, {checkLoops: false}],
     // overwrite recommended: allow `try {foo();} catch (e) {}`
     'no-empty': [2, {allowEmptyCatch: true}],
-    'valid-jsdoc': [
-      2,
-      {
-        requireReturn: false,
-        requireParamDescription: false,
-        requireReturnDescription: false,
-        prefer: {
-          returns: 'return',
-        },
-        preferType: {
-          Boolean: 'boolean',
-          Number: 'number',
-          String: 'string',
-          Null: 'null',
-          Undefined: 'undefined',
-        },
-      },
-    ],
 
     // ## Best Practices
     // These are rules designed to prevent you from making mistakes.
@@ -167,5 +149,52 @@ module.exports = {
     'unicorn/no-hex-escape': 2,
     'unicorn/number-literal-case': 2,
     'unicorn/escape-case': 2,
+
+    // # eslint-plugin-jsdoc
+    // https://github.com/gajus/eslint-plugin-jsdoc
+    'jsdoc/check-param-names': 2,
+    'jsdoc/check-tag-names': 2,
+    'jsdoc/check-types': 2,
+    // Note: missing many global types
+    // 'jsdoc/no-undefined-types': 2,
+    'jsdoc/require-param-name': 2,
+    'jsdoc/valid-types': 2,
+  },
+  settings: {
+    jsdoc: {
+      // https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler
+      tagNamePreference: {
+        arg: 'param',
+        class: 'constructor',
+        constant: 'const',
+        exports: 'export',
+        inheritdoc: 'inheritDoc',
+        returns: 'return',
+      },
+      additionalTagNames: {
+        customTags: [
+          'define',
+          'dict',
+          'extends',
+          'externs',
+          'fileoverview',
+          'final',
+          'modifies',
+          'noalias',
+          'nocollapse',
+          'nosideeffects',
+          'package',
+          'polymer',
+          'polymerBehavior',
+          'preserve',
+          'record',
+          'struct',
+          'suppress',
+          'template',
+          'this',
+          'unrestricted',
+        ],
+      },
+    },
   },
 };

--- a/lib/closure.js
+++ b/lib/closure.js
@@ -13,6 +13,7 @@ module.exports = {
   env: {
     browser: true,
   },
+  plugins: ['jsdoc'],
   rules: {
     // dot at tail of a line
     'dot-location': [2, 'object'],
@@ -32,5 +33,11 @@ module.exports = {
     strict: [2, 'never'],
     // allow both `{"foo": 1}` and `{foo: 1}`
     'quote-props': 0,
+
+    // # eslint-plugin-jsdoc
+    // https://github.com/gajus/eslint-plugin-jsdoc
+    'jsdoc/require-param': 2,
+    'jsdoc/require-param-type': 2,
+    'jsdoc/require-returns-type': 2,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,10 +210,23 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.1.tgz",
+      "integrity": "sha512-6RIp9+7yxmrTjwa1S+fv2eZ2x/ta81pdhOBmRtkY+0o+3tdquvPWqARAv6djmk0YSsAzpx7UgeHcvSv7bHQYCA==",
+      "requires": {
+        "readable-stream": "^2.0.4"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -391,6 +404,16 @@
       "requires": {
         "escape-string-regexp": "^1.0.5",
         "ignore": "^3.3.8"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.14.1.tgz",
+      "integrity": "sha512-rhWrW3UrMt487TCXxSIXW4aCqB3pb1tGAWki0CjWG/ApQdNnhoCs/Lz7EtxOfQfBGvBSjfYiXEEnJRCRMTtubQ==",
+      "requires": {
+        "comment-parser": "^0.5.1",
+        "jsdoctypeparser": "^2.0.0-alpha-8",
+        "lodash": "^4.17.11"
       }
     },
     "eslint-plugin-node": {
@@ -695,8 +718,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.2.1",
@@ -793,6 +815,11 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -814,6 +841,11 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsdoctypeparser": {
+      "version": "2.0.0-alpha-8",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz",
+      "integrity": "sha1-uvE3+44qVYgQrc8Z0tKi9oDpCl8="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -864,8 +896,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -1174,6 +1205,11 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1195,6 +1231,20 @@
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
         "path-type": "^3.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regexpp": {
@@ -1267,6 +1317,11 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -1365,7 +1420,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -1388,6 +1443,14 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.4.3",
         "function-bind": "^1.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1476,6 +1539,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
+    "eslint-plugin-jsdoc": "^3.14.1",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-unicorn": "^6.0.1"
@@ -38,6 +39,7 @@
     "eslint": "^5.11.0",
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
+    "eslint-plugin-jsdoc": "^3.14.1",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.0.0"
   },


### PR DESCRIPTION
- [End\-of\-Life for Built\-in JSDoc Support in ESLint \- ESLint \- Pluggable JavaScript linter](https://eslint.org/blog/2018/11/jsdoc-end-of-life)
- https://qiita.com/mysticatea/items/09f9dd4ab2569cd4cd68