### PR TITLE
feat(es2015): enable `prefer-destructuring`

### DIFF
--- a/examples/es2015/index.js
+++ b/examples/es2015/index.js
@@ -89,3 +89,8 @@ foo.startsWith('bar');
 // prefer-spread: disable
 const args = [];
 foo.apply(undefined, args);
+
+// prefer-destructuring
+const array = [];
+const a0 = array[0];
+const {prop1} = foo;

--- a/lib/es2015.js
+++ b/lib/es2015.js
@@ -27,6 +27,7 @@ module.exports = {
     'object-shorthand': [2, 'methods'],
     'prefer-arrow-callback': [2, {allowNamedFunctions: true}],
     'prefer-const': 2,
+    'prefer-destructuring': [2, {object: true, array: false}],
     'prefer-numeric-literals': 2,
     'prefer-rest-params': 2,
     'prefer-template': 2,

--- a/test/fixtures/es2015.prefer-destructuring.fail.js
+++ b/test/fixtures/es2015.prefer-destructuring.fail.js
@@ -1,0 +1,1 @@
+const foo = object.foo;

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const glob = require('glob');
 const eslint = require('eslint');
 
-const CLIEngine = eslint.CLIEngine;
+const {CLIEngine} = eslint;
 const generateTest = require('./lib/generateTest');
 
 function verify(configName, useModule = false, configFile = `${__dirname}/../${configName}.js`) {

--- a/test/lib/generateTest.js
+++ b/test/lib/generateTest.js
@@ -12,7 +12,7 @@ function formatMessages(messages) {
 
 function generateTest(result) {
   const filePath = path.basename(result.filePath);
-  const messages = result.messages;
+  const {messages} = result;
   const fatals = messages.filter(_ => !!_.fatal);
   if (fatals.length) {
     fatals.forEach(fatal => {


### PR DESCRIPTION
because it supports autofix

- https://qiita.com/mysticatea/items/79df343e19f8608f620a
- https://eslint.org/docs/rules/prefer-destructuring

enable for only objects, not array