### PR TITLE
fix: disable require-await

### DIFF
--- a/lib/es2017.js
+++ b/lib/es2017.js
@@ -19,10 +19,6 @@ module.exports = {
     // no use case
     "no-return-await": 2,
 
-    // experimentally enabled
-    // https://github.com/teppeis/eslint-config-teppeis/pull/52
-    "require-await": 2,
-
     // ## Override
     // ES2017 allows trailing comma in "functions"
     "comma-dangle": [

--- a/test/fixtures/es2017.require-await.fail.js
+++ b/test/fixtures/es2017.require-await.fail.js
@@ -1,5 +1,0 @@
-'use strict';
-
-async function foo() {
-  return bar();
-}


### PR DESCRIPTION
This is enabled experimentally, but it's too strict for me. Thank you.
https://github.com/teppeis/eslint-config-teppeis/pull/52