### PR TITLE
feat(jsdoc): use settings.jsdoc.mode

### DIFF
--- a/+typescript.js
+++ b/+typescript.js
@@ -34,6 +34,9 @@ module.exports = {
         "@typescript-eslint/consistent-type-assertions": 2,
       },
       settings: {
+        jsdoc: {
+          mode: "typescript",
+        },
         node: {
           tryExtensions: [".ts", ".tsx", ".js", ".jsx", ".json", ".node"],
         },

--- a/lib/base.js
+++ b/lib/base.js
@@ -163,52 +163,7 @@ module.exports = {
     // # eslint-plugin-jsdoc
     // https://github.com/gajus/eslint-plugin-jsdoc
     "jsdoc/check-param-names": 2,
-    "jsdoc/check-tag-names": [
-      2,
-      {
-        definedTags: [
-          // https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/parsing/Annotation.java
-          // https://github.com/gajus/eslint-plugin-jsdoc/blob/master/src/tagNames.js
-          "consistentIdGenerator",
-          "customElement",
-          "define",
-          "dict",
-          "disposes",
-          // defined in tagNamePreference
-          // 'export',
-          "expose",
-          "externs",
-          "final",
-          "hidden",
-          "idGenerator",
-          "implicitCast",
-          // defined in tagNamePreference
-          // 'inheritDoc',
-          "meaning",
-          "mixinClass",
-          "mixinFunction",
-          "modifies",
-          "ngInject",
-          "nocollapse",
-          "nocompile",
-          "noinline",
-          "nosideeffects",
-          "owner",
-          "package",
-          "polymer",
-          "polymerBehavior",
-          "preserve",
-          "record",
-          "stableIdGenerator",
-          "struct",
-          "suppress",
-          "template",
-          "typeSummary",
-          "unrestricted",
-          "wizaction",
-        ],
-      },
-    ],
+    "jsdoc/check-tag-names": 2,
     "jsdoc/check-types": [2, { unifyParentAndChildTypeChecks: true }],
     // missing many global types
     // 'jsdoc/no-undefined-types': 2,
@@ -228,7 +183,6 @@ module.exports = {
       },
       // https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler
       tagNamePreference: {
-        arg: "param",
         augments: "extends",
         class: "constructor",
         constant: "const",

--- a/lib/closure.js
+++ b/lib/closure.js
@@ -45,6 +45,7 @@ module.exports = {
   },
   settings: {
     jsdoc: {
+      mode: "closure",
       overrideReplacesDocs: true,
       augmentsExtendsReplacesDocs: true,
       implementsReplacesDocs: false,

--- a/test/fixtures/es5+closure.jsdoc#check-tag-names.pass.js
+++ b/test/fixtures/es5+closure.jsdoc#check-tag-names.pass.js
@@ -1,0 +1,12 @@
+/** @type {number} */
+var id = 1;
+
+/** @define {boolean} */
+var ENABLE_DEBUG = true;
+
+/**
+ * @param {T} t
+ * @constructor
+ * @template T
+ */
+var Container = function(t) {};

--- a/test/fixtures/es5.jsdoc#check-tag-names.pass.js
+++ b/test/fixtures/es5.jsdoc#check-tag-names.pass.js
@@ -1,0 +1,2 @@
+/** @type {number} */
+var id = 1;

--- a/test/fixtures/typescript.jsdoc#check-tag-names.pass.ts
+++ b/test/fixtures/typescript.jsdoc#check-tag-names.pass.ts
@@ -1,0 +1,9 @@
+/** @type {number} */
+var id = 1;
+
+/**
+ * @param {T} t
+ * @constructor
+ * @template T
+ */
+var Container = function(t) {};

--- a/test/index.js
+++ b/test/index.js
@@ -40,10 +40,10 @@ describe("eslint-config-teppeis", () => {
   describeVerify("es2016", true);
   describeVerify("es2017", true);
   describeVerify("es2019", true);
-  describeVerify("+closure", false, "fixtures/.closure.eslintrc.json");
+  describeVerify("es5+closure", false, "fixtures/.closure.eslintrc.json");
   describeVerify("node-v10");
   describeVerify("node-v12");
-  describeVerify("+prettier", false, "fixtures/.prettier.eslintrc.json");
+  // describeVerify("+prettier", false, "fixtures/.prettier.eslintrc.json");
   describeVerify("typescript", true, "fixtures/.typescript.eslintrc.json");
   describeVerify("typescript-with-type", true, "fixtures/.typescript-with-type.eslintrc.json");
 });


### PR DESCRIPTION
BREAKING CHANGE: Closure specific types like `@define` are no longer allowed in non-Closure setting

Fixes #392 