### PR TITLE
fix(jsdoc): update eslint-plugin-jsdoc to v24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -336,9 +336,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "comment-parser": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.2.tgz",
-      "integrity": "sha512-4Rjb1FnxtOcv9qsfuaNuVsmmVn4ooVoBHzYfyKteiXwIU84PClyGA5jASoFMwPV93+FPh9spwueXauxFJZkGAg=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.4.tgz",
+      "integrity": "sha512-Nnl77/mt6sj1BiYSVMeMWzvD0183F2MFOJyFRmZHimUVDYS9J40AvXpiFA7RpU5pQH+HkvYc0dnsHpwW2xmbyQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -563,11 +563,11 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-21.0.0.tgz",
-      "integrity": "sha512-CdLGe2oyw5YAX9rxq9bVz7H2PK+r8PVwdGuvYGMBstpbVD/66yUAgRFQRsJwAsRKLmReo58Lw1jFdNcxdOc4eg==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-25.0.1.tgz",
+      "integrity": "sha512-lLazG3UDlAVZwXs8C+E8OnavzLxXpjx0UtlzhKcXZ5gnzGdxQ9hL3Tab98gJuh2QNZJPBk2jH/BZG2KXjSEkIw==",
       "requires": {
-        "comment-parser": "^0.7.2",
+        "comment-parser": "^0.7.4",
         "debug": "^4.1.1",
         "jsdoctypeparser": "^6.1.0",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@typescript-eslint/parser": "^2.31.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
-    "eslint-plugin-jsdoc": "^21.0.0",
+    "eslint-plugin-jsdoc": "^25.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-unicorn": "^19.0.1",


### PR DESCRIPTION
https://github.com/teppeis/eslint-config-teppeis/pull/420
---
<details>
<summary>gajus/eslint-plugin-jsdoc</summary>

### [`v24.0.6`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.6)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v24.0.5...v24.0.6)

##### Bug Fixes

-   comment-detection logic issue with function expressions within function declarations ([e7720ec](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/e7720eca2eae6498080a3de1638c5319078e70b4))

### [`v24.0.5`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.5)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v24.0.4...v24.0.5)

##### Bug Fixes

-   avoid errors with `getReducedASTNode`; fixes [#&#8203;528](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/528) ([be8d9a3](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/be8d9a3d2e2a3067e7b22cb8db1737ad7571583d))

### [`v24.0.4`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.4)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v24.0.3...v24.0.4)

##### Bug Fixes

-   in conjunction with `comment-parser` update, remove last line break in last tag description for proper stringification (and fix old tests) ([fdf129b](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/fdf129bbb4c4badd5cad0d98f157c0bf46e8da34))

### [`v24.0.3`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.3)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v24.0.2...v24.0.3)

##### Bug Fixes

-   **require-jsdoc:** check above export for named exports; fixes [#&#8203;526](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/526) ([757d97a](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/757d97af4b656bb8c3412b8457b86f4d6fc4a755))

### [`v24.0.2`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.2)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v24.0.1...v24.0.2)

##### Performance Improvements

-   only check moved settings if jsdoc settings exist ([36ede65](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/36ede65022d39c7cd0b7e2d2b7ff9d510d21bbd5))

### [`v24.0.1`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.1)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v24.0.0...v24.0.1)

##### Bug Fixes

-   **require-jsdoc:** placement of jsdoc block by fixer; fixes [#&#8203;369](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/369), [#&#8203;403](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/403), [#&#8203;502](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/502), [#&#8203;522](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/522) ([c1b5b46](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/c1b5b46781f2356405c601c835c636e7cfc33ee7))

### [`v24.0.0`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v24.0.0)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v23.1.0...v24.0.0)

##### Bug Fixes

-   **check-tag-names, empty-tags, require-description, require-example, require-param, require-returns:** explicitly allow `inheritDoc` in all modes while only allowing `inheritdoc` in non-Closure mode; fixes [#&#8203;520](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/520) ([48fc58b](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/48fc58ba8d3870ae8a9b7d5456f5a1efa40c50aa))

##### Features

-   add a global option for checking constructors, getters or setters and remove `avoidExampleOnConstructors` option. ([e5236a2](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/e5236a23a50aeebcb8902bd30c4315ce22519bcc))

##### Reverts

-   Revert "fix(check-tag-names, empty-tags, require-description, require-example, require-param, require-returns) explicitly allow `inheritDoc` in all modes while only allowing `inheritdoc` in non-Closure mode; fixes [#&#8203;520](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/520)" ([d97c8f0](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/d97c8f076b55ffd28da6ff6b6948c5af6c322a18)), closes [#&#8203;520](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/520)

##### BREAKING CHANGES

-   Replaces the option `avoidExampleOnConstructors` for
    the `require-example` rule by `checkConstructors`

Also makes build-call platform independent and ensures env-variables work an all platforms.

### [`v23.1.0`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v23.1.0)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v23.0.1...v23.1.0)

##### Features

-   **require-param:** further support for typescript functions; closes [#&#8203;512](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/512) ([fe637d5](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/fe637d509def2ecd92e70a943ef03ef485bc9c0d))

### [`v23.0.1`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v23.0.1)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v23.0.0...v23.0.1)

##### Bug Fixes

-   **require-jsdoc:** allow requiring of `MethodDefinition` with `publicOnly` ESM export; fixes [#&#8203;519](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/519) ([dfde551](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/dfde5519074b89d1aae0ab4a88de0876a50e1392))

### [`v23.0.0`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v23.0.0)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v22.2.0...v23.0.0)

##### Features

-   **`require-description`, `require-example`, `require-param`, `require-returns`:** cause `exemptedBy` to overwrite `inheritdoc` exempting; closes [#&#8203;510](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/510) ([a402330](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/a4023308851719285383fa36ea7c40b66db4c8c9))

##### BREAKING CHANGES

-   **`require-description`, `require-example`, `require-param`, `require-returns`:** While still defaulting to having `inheritdoc` exempt rules, for the impacted rules,
    if one has defined an `exemptedBy` options array one must now explicitly add
    back `"inheritdoc"` to get the exemption for that tag as well. This change allows
    users to omit `inheritdoc` from the array so as to cause its presence not to
    trigger exemption of the rule.

### [`v22.2.0`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v22.2.0)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v22.1.0...v22.2.0)

##### Features

-   **`require-param`:** add `contexts` option; closes [#&#8203;511](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/511) ([3aaba73](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/3aaba73ee6e7ff8145f4470a69d42be779148753))

### [`v22.1.0`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v22.1.0)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v22.0.1...v22.1.0)

##### Features

-   **`require-returns`:** add `checkGetter` option to be able to disable enforcement on getters ([eb3cc84](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/eb3cc84f508ecf064042437bc455f8a1d4a9be15))

### [`v22.0.1`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v22.0.1)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v22.0.0...v22.0.1)

##### Bug Fixes

-   **`require-jsdoc`:** ensure `exemptEmptyFunctions` doesn't attempt to apply when non-function contexts are in use (causing errors); fixes [#&#8203;501](https://togithub.com/gajus/eslint-plugin-jsdoc/issues/501) ([7daf934](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/7daf9340bd45c866e65975339b9e861b376fc1fc))

### [`v22.0.0`](https://togithub.com/gajus/eslint-plugin-jsdoc/releases/v22.0.0)

[Compare Source](https://togithub.com/gajus/eslint-plugin-jsdoc/compare/v21.0.0...v22.0.0)

-   chore; drop eslint 5 ([3c9d20f](https://togithub.com/gajus/eslint-plugin-jsdoc/commit/3c9d20fc98f286d68489ab456cc1a3325bd9622f))

##### BREAKING CHANGES

-   Drops ESLint@5 support

</details>
