### PR TITLE
feat(node-v12, node-v14): add numeric separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Chose config for specific Node version
 
 - `teppeis/node-v10` (v10.17+ for `fs.promises`, etc)
 - `teppeis/node-v12` (v12.12+ for `module.syncBuiltinESMExports()`)
-- `teppeis/node-v14` (v14.0+)
+- `teppeis/node-v14` (v14.15+ LTS)
 
 #### With Babel or other transpilers
 
@@ -158,7 +158,7 @@ It also enables ES Modules.
 ## License
 
 Licensed under the MIT license.
-Copyright (c) 2020, Teppei Sato
+Copyright (c) 2021, Teppei Sato
 
 [npm-image]: https://img.shields.io/npm/v/eslint-config-teppeis.svg
 [npm-url]: https://npmjs.org/package/eslint-config-teppeis

--- a/lib/es2021-numeric-separators.js
+++ b/lib/es2021-numeric-separators.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 2021,
+  },
+  rules: {
+    "unicorn/numeric-separators-style": [
+      "error",
+      { onlyIfContainsSeparator: true, number: { minimumDigits: 0 } },
+    ],
+  },
+};

--- a/lib/es2021.js
+++ b/lib/es2021.js
@@ -1,6 +1,7 @@
 "use strict";
 
 module.exports = {
+  extends: ["./es2021-numeric-separators.js"],
   parserOptions: {
     ecmaVersion: 2021,
   },
@@ -8,11 +9,5 @@ module.exports = {
     WeakRef: "readonly",
     FinalizationRegistry: "readonly",
     AggregateError: "readonly",
-  },
-  rules: {
-    "unicorn/numeric-separators-style": [
-      "error",
-      { onlyIfContainsSeparator: true, number: { minimumDigits: 0 } },
-    ],
   },
 };

--- a/node-v12.js
+++ b/node-v12.js
@@ -14,6 +14,7 @@ module.exports = {
     "./lib/es2018.js",
     "./lib/es2019.js",
     "./lib/es2020.js",
+    "./lib/es2021-numeric-separators.js",
   ],
   // Node v12 doesn't support optional chaining and nullish coalescing (ES2020)
   rules: {

--- a/node-v14.js
+++ b/node-v14.js
@@ -12,6 +12,7 @@ module.exports = {
     "./lib/es2017.js",
     "./lib/es2018.js",
     "./lib/es2019.js",
+    "./lib/es2020.js",
     "./lib/es2021-numeric-separators.js",
   ],
   rules: {

--- a/node-v14.js
+++ b/node-v14.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const version = ">=14.0.0 <15";
+// LTS 'Fermium' from v14.15.0
+const version = ">=14.15.0 <15";
 
 module.exports = {
   extends: [
@@ -11,12 +12,12 @@ module.exports = {
     "./lib/es2017.js",
     "./lib/es2018.js",
     "./lib/es2019.js",
-    "./lib/es2020.js",
+    "./lib/es2021-numeric-separators.js",
   ],
   rules: {
     // eslint-plugin-node has not been updated for Node v14
     "node/no-unsupported-features/es-builtins": [0, { version }],
     "node/no-unsupported-features/es-syntax": [0, { version }],
-    "node/no-unsupported-features/node-builtins": [2, { version }],
+    "node/no-unsupported-features/node-builtins": [0, { version }],
   },
 };


### PR DESCRIPTION
- add numeric separators to `node-v12` and `node-v14`
- `node-v14` support Node v14.15.0+ (LTS)
- `node-v14` disable `node/no-unsupported-features/node-builtins`