### PR TITLE
fix: replace deprecated core rules with eslint-plugin-node

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -6,18 +6,15 @@ module.exports = {
     node: true,
   },
   rules: {
-    // ## Node.js and CommonJS
-    // These rules are specific to JavaScript running on Node.js or using CommonJS in the browser.
-    "handle-callback-err": 2,
-    "no-new-require": 2,
-
     // ## eslint-plugin-node
+    "node/handle-callback-err": 2,
     "node/no-deprecated-api": 2,
     "node/no-extraneous-import": 2,
     "node/no-extraneous-require": 2,
     // use "import/no-unresolved" instead
     // "node/no-missing-import": 2,
     "node/no-missing-require": 2,
+    "node/no-new-require": 2,
     "node/no-unpublished-bin": 2,
     "node/no-unpublished-import": 2,
     "node/no-unpublished-require": 2,


### PR DESCRIPTION
https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-node-rules