### PR TITLE
feat(+typescript, +module)!: support TypeScript ESM

### DIFF
--- a/+module.js
+++ b/+module.js
@@ -34,6 +34,9 @@ module.exports = {
       },
     ],
   },
+  settings: {
+    "import/extensions": [".js", ".jsx", ".mjs"],
+  },
   overrides: [
     {
       // for non-TypeScript files

--- a/+module.js
+++ b/+module.js
@@ -9,7 +9,14 @@ module.exports = {
     // for both TypeScript and non-TypeScript rules
 
     // ** Static analysis **
+    "import/no-absolute-path": 2,
     "import/no-useless-path-segments": 2,
+    // for monorepo
+    "import/no-relative-packages": 2,
+
+    // ** Helpful warnings **
+    "import/no-deprecated": 2,
+    "import/no-mutable-exports": 2,
 
     // ** Style guide **
     // "always" for Native ESM, "never" for CJS/TS
@@ -37,7 +44,6 @@ module.exports = {
         "import/default": 2,
         "import/named": 2,
         "import/namespace": 2,
-        "import/no-absolute-path": 2,
         "import/no-self-import": 2,
         "import/no-unresolved": [2, { caseSensitiveStrict: true }],
 

--- a/+module.js
+++ b/+module.js
@@ -20,7 +20,6 @@ module.exports = {
 
     // ** Style guide **
     // "always" for Native ESM, "never" for CJS/TS
-    // "import/extensions": 2,
     "import/first": 2,
     "import/newline-after-import": 2,
     "import/no-duplicates": 2,
@@ -51,6 +50,9 @@ module.exports = {
         "import/export": 2,
         "import/no-named-as-default": 2,
         // "import/no-named-as-default-member": 2,
+
+        // ** Style guide **
+        "import/extensions": [2, "always"],
       },
     },
   ],

--- a/+typescript.js
+++ b/+typescript.js
@@ -1,14 +1,12 @@
 "use strict";
 
+const TS_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
+
 module.exports = {
   overrides: [
     {
       files: ["*.ts", "*.tsx", ".mts", ".cts"],
-      extends: [
-        "plugin:@typescript-eslint/recommended",
-        "./+module.js",
-        "plugin:import/typescript",
-      ],
+      extends: ["plugin:@typescript-eslint/recommended", "./+module.js"],
       rules: {
         // ES2019 available in TypeScript
         "node/no-unsupported-features/es-syntax": 0,
@@ -62,8 +60,12 @@ module.exports = {
             ".node",
           ],
         },
+        "import/external-module-folders": ["node_modules", "node_modules/@types"],
+        "import/parsers": {
+          "@typescript-eslint/parser": TS_EXTENSIONS,
+        },
         "import/resolver": {
-          typescript: {},
+          typescript: TS_EXTENSIONS,
         },
       },
     },

--- a/+typescript.js
+++ b/+typescript.js
@@ -18,11 +18,11 @@ module.exports = {
 
         // Extend ESLint rules
         // skip extending stylistic rules that are overrided by prettier
-        "no-invalid-this": 2,
+        "no-invalid-this": 0,
         "@typescript-eslint/no-invalid-this": 2,
-        "no-loop-func": 2,
+        "no-loop-func": 0,
         "@typescript-eslint/no-loop-func": 2,
-        "no-unused-expressions": "off",
+        "no-unused-expressions": 0,
         "@typescript-eslint/no-unused-expressions": [
           2,
           { allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true },

--- a/+typescript.js
+++ b/+typescript.js
@@ -37,6 +37,7 @@ module.exports = {
         // Additional rules
         "@typescript-eslint/consistent-type-assertions": 2,
         "@typescript-eslint/consistent-type-imports": 2,
+        "@typescript-eslint/no-duplicate-enum-values": 2,
         "@typescript-eslint/no-useless-empty-export": 2,
         // allow require for power-assert
         // '@typescript-eslint/no-require-imports': 2,

--- a/+typescript.js
+++ b/+typescript.js
@@ -3,7 +3,7 @@
 module.exports = {
   overrides: [
     {
-      files: ["*.ts", "*.tsx"],
+      files: ["*.ts", "*.tsx", ".mts", ".cts"],
       extends: [
         "plugin:@typescript-eslint/recommended",
         "./+module.js",
@@ -49,7 +49,18 @@ module.exports = {
           mode: "typescript",
         },
         node: {
-          tryExtensions: [".ts", ".tsx", ".js", ".jsx", ".json", ".node"],
+          tryExtensions: [
+            ".ts",
+            ".mts",
+            ".cts",
+            ".tsx",
+            ".js",
+            ".mjs",
+            ".cjs",
+            ".jsx",
+            ".json",
+            ".node",
+          ],
         },
         "import/resolver": {
           typescript: {},

--- a/+typescript.js
+++ b/+typescript.js
@@ -31,7 +31,7 @@ module.exports = {
         // Override recommended rules
         "@typescript-eslint/no-explicit-any": 0,
         "@typescript-eslint/no-namespace": [2, { allowDeclarations: true }],
-        "@typescript-eslint/no-non-null-assertion": 2,
+        "@typescript-eslint/no-non-null-assertion": 2, // warn to error
         "@typescript-eslint/no-unused-vars": [2, { args: "none" }],
 
         // Additional rules

--- a/examples/module/order.js
+++ b/examples/module/order.js
@@ -1,15 +1,12 @@
-/* eslint-disable import/no-duplicates */
-/* eslint-disable import/no-useless-path-segments */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/default */
 import eslint from 'eslint';
 import os from 'os';
 import index from '.';
-import parent2 from '../../parent2';
-import parent1 from '../parent';
-import indexSlash from './';
-import sibling2 from './sibling';
-import sibling1 from './sibling/foo';
+import parent2 from '../../parent2.js';
+import parent1 from '../parent.js';
+import sibling2 from './sibling.js';
+import sibling1 from './sibling/foo.js';
 
 // eslint-disable-next-line no-undef
 console.log(os, eslint, sibling2, sibling1, parent1, parent2, index, indexSlash);


### PR DESCRIPTION
- support .mjs, .cjs, .mts and .cts
- enable rules
  - import/no-relative-packages
  - import/no-deprecated
  - import/no-mutable-exports
  - import/extensions
- fix to disable overridden core rules