### PR TITLE
fix(deps): pin eslint-plugin-import to ~2.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "eslint-config-prettier": "^8.7.0",
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-import": "~2.26.0",
         "eslint-plugin-jsdoc": "^40.1.0",
         "eslint-plugin-n": "^15.6.1",
         "eslint-plugin-unicorn": "^46.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-config-prettier": "^8.7.0",
     "eslint-import-resolver-typescript": "^3.5.3",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^40.1.0",
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-unicorn": "^46.0.0"


### PR DESCRIPTION
eslint-plugin-import v2.27.0 has a breaking change about import/order