### PR TITLE
fix(import/order): disable alphabetize option, prefer tsc organize-import

### DIFF
--- a/lib/module-base.js
+++ b/lib/module-base.js
@@ -31,11 +31,7 @@ module.exports = {
     "import/order": [
       2,
       {
-        groups: [
-          ["builtin", "external", "internal"],
-          ["index", "parent", "sibling"],
-        ],
-        alphabetize: { order: "asc", caseInsensitive: true },
+        groups: [["builtin", "external"], "internal", "index", "parent", "sibling"],
       },
     ],
   },


### PR DESCRIPTION
see
- https://github.com/teppeis/eslint-config-teppeis/pull/892
- https://github.com/import-js/eslint-plugin-import/pull/2396