### PR TITLE
fix: use eslint prefer-exponentiation-operator instead unicorn

### DIFF
--- a/lib/es2015.js
+++ b/lib/es2015.js
@@ -28,6 +28,7 @@ module.exports = {
     "prefer-arrow-callback": [2, { allowNamedFunctions: true }],
     "prefer-const": 2,
     "prefer-destructuring": [2, { object: true, array: false }],
+    "prefer-exponentiation-operator": 2,
     "prefer-numeric-literals": 2,
     "prefer-rest-params": 2,
     "prefer-template": 2,
@@ -41,7 +42,6 @@ module.exports = {
     // https://github.com/sindresorhus/eslint-plugin-unicorn
     "unicorn/custom-error-definition": 2,
     "unicorn/no-typeof-undefined": 2,
-    "unicorn/prefer-exponentiation-operator": 2,
     "unicorn/prefer-string-starts-ends-with": 2,
   },
 };


### PR DESCRIPTION
deprecated in unicorn https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v16.0.0