### PR TITLE
refactor(types): cleanup type definitions

### DIFF
--- a/src/types/@eslint-community/eslint-plugin-eslint-comments.d.ts
+++ b/src/types/@eslint-community/eslint-plugin-eslint-comments.d.ts
@@ -1,1 +1,22 @@
-declare module "@eslint-community/eslint-plugin-eslint-comments/configs";
+declare module "@eslint-community/eslint-plugin-eslint-comments/configs" {
+  import type { Linter } from "eslint";
+
+  interface Configs {
+    recommended: {
+      name: "@eslint-community/eslint-comments/recommended";
+      plugins: {
+        "@eslint-community/eslint-comments": Linter.Plugin;
+      };
+      rules: {
+        "@eslint-community/eslint-comments/disable-enable-pair": "error";
+        "@eslint-community/eslint-comments/no-aggregating-enable": "error";
+        "@eslint-community/eslint-comments/no-duplicate-disable": "error";
+        "@eslint-community/eslint-comments/no-unlimited-disable": "error";
+        "@eslint-community/eslint-comments/no-unused-enable": "error";
+      };
+    };
+  }
+
+  const configs: Configs;
+  export default configs;
+}

--- a/src/types/eslint-plugin-import.d.ts
+++ b/src/types/eslint-plugin-import.d.ts
@@ -1,1 +1,0 @@
-declare module "eslint-plugin-import";

--- a/src/types/eslint-plugin-jsdoc.d.ts
+++ b/src/types/eslint-plugin-jsdoc.d.ts
@@ -1,1 +1,0 @@
-declare module "eslint-plugin-jsdoc";

--- a/src/types/eslint-plugin-n.d.ts
+++ b/src/types/eslint-plugin-n.d.ts
@@ -1,1 +1,0 @@
-declare module "eslint-plugin-n";


### PR DESCRIPTION
- Remove unnecessary type definitions for packages that include their own types:
  - eslint-plugin-import
  - eslint-plugin-n
  - eslint-plugin-jsdoc
- Restore and improve type definitions for @eslint-community/eslint-plugin-eslint-comments